### PR TITLE
anti-dos

### DIFF
--- a/files/var/www/a/main.js
+++ b/files/var/www/a/main.js
@@ -55,7 +55,7 @@ function heartbeat() {
                  $('#daynight_value').textContent = '☀️ ' + json.daynight_value;
              }
          })
-         .then(setTimeout(heartbeat, 1000));
+         .then(setTimeout(heartbeat, 3000));
 }
 
 (function () {

--- a/files/var/www/cgi-bin/j/heartbeat.cgi
+++ b/files/var/www/cgi-bin/j/heartbeat.cgi
@@ -11,7 +11,10 @@ else
 fi
 
 if [ ! -z $(pidof majestic) ]; then
-	daynight_value=$(curl -s http://127.0.0.1/metrics?value=isp_again)
+	daynight_value=$(timeout .5 wget -q -O - http://127.0.0.1/metrics?value=isp_again)
+	if [ -z ] "$daynight_value" ]; then
+		daynight_value=-1
+	fi
 fi
 
 if [ -z "$daynight_value" ]; then


### PR DESCRIPTION
Frequent curl polls to `http://127.0.0.1/metrics?value=isp_again` could previously overload the http server, causing requests to pile up, resulting in an unresponsive camera.
As a quick fix, I have: 
- changed curl to wget and gave it a timeout of .5 seconds, well below the refresh interval
- changed the refresh interval of hearbeat.cgi calls to 3 seconds instead of 1
- set daynight_value to return -1 in case the request to `metrics?value=isp_again` returns no value, this prevents a 500 error on heartbeat.cgi, giving the web interface a malformed response.