### PR TITLE
Update firmware version prefix

### DIFF
--- a/files/var/www/cgi-bin/firmware.cgi
+++ b/files/var/www/cgi-bin/firmware.cgi
@@ -21,7 +21,7 @@ if [ -n "$network_gateway" ]; then
 			url="https://github.com/OpenIPC/firmware/releases/download/latest/openipc.${soc}-${flash_type}-${fw_variant}.tgz"
 			 ;;
 	esac
-	fw_date=$(date -D "%a, %d %b %Y %T GMT" +"2.3.%m.%d" --date "$(curl -ILs "$url" | grep Last-Modified | cut -d' ' -f2-)")
+	fw_date=$(date -D "%a, %d %b %Y %T GMT" +"2.4.%m.%d" --date "$(curl -ILs "$url" | grep Last-Modified | cut -d' ' -f2-)")
 else
 	fw_date="<span class=\"text-danger\">- no access to GitHub -</span>"
 fi


### PR DESCRIPTION
Updates from 2.3 to 2.4 to reflect that the year is now 2024 / to match the actual firmware version numbers