### PR TITLE
Fixed wi-fi setup through web

### DIFF
--- a/files/usr/sbin/setnetiface.sh
+++ b/files/usr/sbin/setnetiface.sh
@@ -191,7 +191,7 @@ fi
 
 if [ "wlan0" = "$network_interface" ]; then
 	tmp_env_file=$(mktemp)
-	printf "wlandev %s\nwlanssid %s\nwlanpass %s" "$network_device" "$network_ssid" "$network_password" >"$tmp_env_file"
+	printf "wlandev %s\nwlanssid %s\nwlanpass %s\n" "$network_device" "$network_ssid" "$network_password" >"$tmp_env_file"
 	fw_setenv -s "$tmp_env_file"
 
 	printf "$TEMPLATE_WIRELESS" $network_ssid $network_password >>"$tmp_config_file"

--- a/files/var/www/cgi-bin/network.cgi
+++ b/files/var/www/cgi-bin/network.cgi
@@ -34,7 +34,7 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
 				sanitize "${plugin}_${p}"
 			done; unset p
 
-			network_interface=$(echo $network_interfaces | cut -d' ' -f1)
+			#network_interface=$(echo $network_interfaces | cut -d' ' -f1)
 
 			[ -z "$network_interface" ] && set_error_flag "Default network interface cannot be empty."
 

--- a/files/var/www/cgi-bin/p/common.cgi
+++ b/files/var/www/cgi-bin/p/common.cgi
@@ -651,6 +651,9 @@ sanitize() {
 	eval $n=$(echo \${$n//\\\"/\\\\\\\"})
 	# escape varialbles
 	eval $n=$(echo \${$n//\$/\\\\\$})
+	# escape partnersis
+	eval $n=$(echo \${$n//\\\(/\\\\\\\(})
+	eval $n=$(echo \${$n//\\\)/\\\\\\\)})
 }
 
 sanitize4web() {


### PR DESCRIPTION
Fixed bugs:
1. Ignoring wlan0 as network when passed through POST
2. Brackets in password could not be saved
3. Wi-Fi password coudn't be saved with fw_setenv caused by invalid setenv script file