### PR TITLE
Update firmware-reset.cgi

### DIFF
--- a/files/var/www/cgi-bin/firmware-reset.cgi
+++ b/files/var/www/cgi-bin/firmware-reset.cgi
@@ -2,7 +2,7 @@
 <%in p/common.cgi %>
 <%
 page_title="Erasing overlay"
-c="/usr/sbin/sysupgrade.sh -n"
+c="/usr/sbin/sysupgrade -n"
 reboot="true"
 %>
 <%in p/header.cgi %>


### PR DESCRIPTION
Fixed a typo in the sysupgrade command. Now the settings are reset correctly.